### PR TITLE
Added version ^9.0.0 of @ngx-translate/core to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "typings": "index.d.ts",
   "peerDependencies": {
     "@angular/core": "^2.0.0 || ^4.0.0 || ^5.0.0",
-    "@ngx-translate/core": "^7.2.0 || ^8.0.0",
+    "@ngx-translate/core": "^7.2.0 || ^8.0.0 || ^9.0.0",
     "messageformat": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To remove warning: npm WARN ngx-translate-messageformat-compiler@2.0.1 requires a peer of @ngx-translate/core@^7.2.0 || ^8.0.0 but none is installed. You must install peer dependencies yourself.