### PR TITLE
Fix if language not "en".

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ You no longer need to provide a MessageFormat instance.
 The compiler will do this. You still need to have `messageformat` installed, of course.
 See CHANGELOG for more details.
 
+### Integration with ngx-translate
+
 You need to configure `TranslateModule` so it uses `TranslateMessageFormatCompiler` as the compiler:
 
 ```ts
@@ -61,15 +63,38 @@ import { AppComponent } from "./app";
 export class AppModule {}
 ```
 
-MessageFormat instances provide some methods to influence its behaviour, among them `setBiDiSupport`, and `setStrictNumberSign`. Learn about their meaning here: https://messageformat.github.io/messageformat/MessageFormat
-
 You can override the values used when configuring MessageFormat by providing a configuration object for the `MESSAGE_FORMAT_CONFIG` injection token. Here's the default:
 ```ts
 {
   biDiSupport: false,
+  locales: undefined,
   strictNumberSign: false
 }
 ```
+
+### Locale initialization
+
+By default, messageformat initializes *all* locales. It is recommended that you indicate which locales you will need, like this:
+
+```ts
+import { MESSAGE_FORMAT_CONFIG } from 'ngx-translate-messageformat-compiler';
+
+@NgModule({
+  // ...
+  providers: [
+    { provide: MESSAGE_FORMAT_CONFIG, useValue: { locales: ['ar', 'fr'] }}
+  ]
+
+})
+```
+
+The value for `locales` is either a string or an array of strings. More info here: https://messageformat.github.io/messageformat/MessageFormat
+
+**Important** There is currently an issue in messageformat which means that you *have to* initialize your locales if you want to use "composed" locale codes, such as `de-CH`, `fr-CA`, `en-GB` and so on.
+
+### Advanced configuration
+
+MessageFormat instances provide some methods to influence its behaviour, among them `setBiDiSupport`, and `setStrictNumberSign`. Learn about their meaning here: https://messageformat.github.io/messageformat/MessageFormat
 
 This is how you would enable bi-directional support, for example:
 ```ts
@@ -82,7 +107,6 @@ import { MESSAGE_FORMAT_CONFIG } from 'ngx-translate-messageformat-compiler';
   ]
 
 })
-}
 ```
 
 ## Usage

--- a/src/message-format-config.ts
+++ b/src/message-format-config.ts
@@ -7,9 +7,11 @@ export const MESSAGE_FORMAT_CONFIG = new InjectionToken<MessageFormatConfig>(
 export interface MessageFormatConfig {
   biDiSupport?: boolean;
   strictNumberSign?: boolean;
+  languages?: string | string[];
 }
 
 export const defaultConfig: MessageFormatConfig = {
   biDiSupport: false,
+  languages: undefined,
   strictNumberSign: false
 };

--- a/src/message-format-config.ts
+++ b/src/message-format-config.ts
@@ -6,12 +6,12 @@ export const MESSAGE_FORMAT_CONFIG = new InjectionToken<MessageFormatConfig>(
 
 export interface MessageFormatConfig {
   biDiSupport?: boolean;
+  locales?: string | string[];
   strictNumberSign?: boolean;
-  languages?: string | string[];
 }
 
 export const defaultConfig: MessageFormatConfig = {
   biDiSupport: false,
-  languages: undefined,
+  locales: undefined,
   strictNumberSign: false
 };

--- a/src/translate-message-format-compiler.spec.ts
+++ b/src/translate-message-format-compiler.spec.ts
@@ -110,20 +110,88 @@ describe("TranslateMessageFormatCompiler", () => {
         "3 pies"
       );
     });
+
+    it("should respect passed-in locales", () => {
+      const msg = "{s}";
+
+      // all locales
+      compiler = new TranslateMessageFormatCompiler();
+      expect(compiler.compile(msg, "en")({ s: "en" })).toBe("en");
+      expect(compiler.compileTranslations({ msg }, "fi").msg({ s: "fi" })).toBe(
+        "fi"
+      );
+      expect(compiler.compile(msg, "de-CH")({ s: "de-CH" })).toBe("de-CH");
+      expect(
+        compiler.compileTranslations({ msg }, "en-UK").msg({ s: "en-GB" })
+      ).toBe("en-GB");
+
+      // one locale
+      compiler = new TranslateMessageFormatCompiler({ locales: "es" });
+      expect(compiler.compile(msg, "es")({ s: "es" })).toBe("es");
+      expect(compiler.compileTranslations({ msg }, "es").msg({ s: "es" })).toBe(
+        "es"
+      );
+      expect(() => compiler.compile(msg, "en")({ s: "en" })).toThrowError();
+      expect(() =>
+        compiler.compileTranslations({ msg }, "en").msg({ s: "en" })
+      ).toThrowError();
+
+      // multiple locales
+      compiler = new TranslateMessageFormatCompiler({
+        locales: ["fr-LU", "it"]
+      });
+      expect(compiler.compile(msg, "fr-LU")({ s: "fr-LU" })).toBe("fr-LU");
+      expect(compiler.compileTranslations({ msg }, "it").msg({ s: "it" })).toBe(
+        "it"
+      );
+      expect(() => compiler.compile(msg, "en")({ s: "en" })).toThrowError();
+      expect(() =>
+        compiler.compileTranslations(msg, "en").msg({ s: "en" })
+      ).toThrowError();
+    });
   });
 
   describe("compile", () => {
     let icuString: string;
 
     beforeEach(() => {
-      compiler = new TranslateMessageFormatCompiler();
       icuString =
         "{count, plural, =0{No} one{A} other{Several}} {count, plural, one{word} other{words}}";
     });
 
-    it("should return the compilation function", () => {
-      const result = compiler.compile(icuString, "en");
-      expect(result({ count: 1 })).toBe("A word");
+    describe("with all locales initialized", () => {
+      beforeEach(() => {
+        compiler = new TranslateMessageFormatCompiler();
+      });
+
+      it("should return the compilation function for simple locales", () => {
+        const result = compiler.compile(icuString, "en");
+        expect(result({ count: 1 })).toBe("A word");
+      });
+
+      xit("should return the compilation function for composed locales", () => {
+        // fails, see https://github.com/lephyrus/ngx-translate-messageformat-compiler/pull/29#issuecomment-410052125
+        const result = compiler.compile(icuString, "en-GB");
+        expect(result({ count: 1 })).toBe("A word");
+      });
+    });
+
+    describe("with specific locales initialized", () => {
+      beforeEach(() => {
+        compiler = new TranslateMessageFormatCompiler({
+          locales: ["en", "en-GB"]
+        });
+      });
+
+      it("should return the compilation function for simple locales", () => {
+        const result = compiler.compile(icuString, "en");
+        expect(result({ count: 1 })).toBe("A word");
+      });
+
+      it("should return the compilation function for composed locales", () => {
+        const result = compiler.compile(icuString, "en-GB");
+        expect(result({ count: 1 })).toBe("A word");
+      });
     });
   });
 
@@ -131,7 +199,6 @@ describe("TranslateMessageFormatCompiler", () => {
     let translations: object;
 
     beforeEach(() => {
-      compiler = new TranslateMessageFormatCompiler();
       translations = {
         alpha: {
           one:
@@ -142,19 +209,51 @@ describe("TranslateMessageFormatCompiler", () => {
       };
     });
 
-    it("should return a corresponding object of compilation functions", () => {
-      const result = compiler.compileTranslations(translations, "en");
-      expect(result.alpha.one({ count: 1 })).toBe("A word");
-      expect(result.alpha.two({ gender: "female", how: "cool" })).toBe(
-        "She is cool"
-      );
+    describe("with all locales initialized", () => {
+      beforeEach(() => {
+        compiler = new TranslateMessageFormatCompiler();
+      });
+
+      it("should return a corresponding object of compilation functions for simple locales", () => {
+        const result = compiler.compileTranslations(translations, "en");
+        expect(result.alpha.one({ count: 1 })).toBe("A word");
+        expect(result.alpha.two({ gender: "female", how: "cool" })).toBe(
+          "She is cool"
+        );
+      });
+
+      xit("should return a corresponding object of compilation functions for composed locales", () => {
+        // fails, see https://github.com/lephyrus/ngx-translate-messageformat-compiler/pull/29#issuecomment-410052125
+        const result = compiler.compileTranslations(translations, "en-GB");
+        expect(result.alpha.one({ count: 1 })).toBe("A word");
+        expect(result.alpha.two({ gender: "female", how: "cool" })).toBe(
+          "She is cool"
+        );
+      });
     });
 
-    it("should return a corresponding object of compilation functions (other languages) ", () => {
-      compiler = new TranslateMessageFormatCompiler({languages:["en-US"]});
-      const obj = { month: "{month} Month{month, plural, one{} other{s}}" };
-      const result = compiler.compileTranslations(obj, "en-US");
-      expect(result.month({ month: 3 })).toBe("3 Months");
+    describe("with specific locales initialized", () => {
+      beforeEach(() => {
+        compiler = new TranslateMessageFormatCompiler({
+          locales: ["en", "en-GB"]
+        });
+      });
+
+      it("should return a corresponding object of compilation functions for simple locales", () => {
+        const result = compiler.compileTranslations(translations, "en");
+        expect(result.alpha.one({ count: 1 })).toBe("A word");
+        expect(result.alpha.two({ gender: "female", how: "cool" })).toBe(
+          "She is cool"
+        );
+      });
+
+      it("should return a corresponding object of compilation functions for composed locales", () => {
+        const result = compiler.compileTranslations(translations, "en-GB");
+        expect(result.alpha.one({ count: 1 })).toBe("A word");
+        expect(result.alpha.two({ gender: "female", how: "cool" })).toBe(
+          "She is cool"
+        );
+      });
     });
   });
 });

--- a/src/translate-message-format-compiler.spec.ts
+++ b/src/translate-message-format-compiler.spec.ts
@@ -1,7 +1,7 @@
 import { TranslateMessageFormatCompiler } from "./translate-message-format-compiler";
 
 describe("TranslateMessageFormatCompiler", () => {
-  const toCharCodes = (value: String) =>
+  const toCharCodes = (value: string) =>
     Array.from(value).map(char => char.charCodeAt(0));
 
   let compiler: TranslateMessageFormatCompiler;
@@ -11,7 +11,7 @@ describe("TranslateMessageFormatCompiler", () => {
       compiler = new TranslateMessageFormatCompiler();
 
       // BiDiSupport: false
-      const result = compiler.compile("{0} >> {1} >> {2}", "en")([
+      const result = compiler.compile("{0} >> {1} >> {2}", "en-US")([
         "a",
         "\u05d1",
         "\u05d2"
@@ -128,7 +128,7 @@ describe("TranslateMessageFormatCompiler", () => {
   });
 
   describe("compileTranslations", () => {
-    let translations: Object;
+    let translations: object;
 
     beforeEach(() => {
       compiler = new TranslateMessageFormatCompiler();
@@ -148,6 +148,13 @@ describe("TranslateMessageFormatCompiler", () => {
       expect(result.alpha.two({ gender: "female", how: "cool" })).toBe(
         "She is cool"
       );
+    });
+
+    it("should return a corresponding object of compilation functions (other languages) ", () => {
+      compiler = new TranslateMessageFormatCompiler({languages:["en-US"]});
+      const obj = { month: "{month} Month{month, plural, one{} other{s}}" };
+      const result = compiler.compileTranslations(obj, "en-US");
+      expect(result.month({ month: 3 })).toBe("3 Months");
     });
   });
 });

--- a/src/translate-message-format-compiler.ts
+++ b/src/translate-message-format-compiler.ts
@@ -22,8 +22,8 @@ export class TranslateMessageFormatCompiler extends TranslateCompiler {
     super();
 
     config = { ...defaultConfig, ...config };
-    
-    this.messageFormat = new MessageFormat(config.languages)
+
+    this.messageFormat = new MessageFormat(config.locales)
       .setBiDiSupport(config.biDiSupport)
       .setStrictNumberSign(config.strictNumberSign);
   }

--- a/src/translate-message-format-compiler.ts
+++ b/src/translate-message-format-compiler.ts
@@ -22,8 +22,8 @@ export class TranslateMessageFormatCompiler extends TranslateCompiler {
     super();
 
     config = { ...defaultConfig, ...config };
-
-    this.messageFormat = new MessageFormat()
+    
+    this.messageFormat = new MessageFormat(config.languages)
       .setBiDiSupport(config.biDiSupport)
       .setStrictNumberSign(config.strictNumberSign);
   }


### PR DESCRIPTION
If lang is not "en" ("en" is messageformat default language), messageformat will throw errors.

So, I add a languages property in MessageFormatConfig to configure messageformat.