### PR TITLE
fixes docu for proper forwarding of the translate params when using the pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ Here's an example to get you started:
 <ul>
   <li translate [translateParams]="{ count: 0 }">things</li>
   <li translate [translateParams]="{ count: 1 }">things</li>
-  <li>{{'things' | translate:"{ count: 2 }"}}</li>
+  <li>{{'things' | translate:{ count: 2 } }}</li>
 </ul>
 <ul>
   <li translate [translateParams]="{ gender: 'female', how: 'influential' }">people</li>
   <li translate [translateParams]="{ gender: 'male', how: 'funny' }">people</li>
-  <li>{{'people' | translate:"{ how: 'affectionate' }"}}</li>
+  <li>{{'people' | translate:{ how: 'affectionate' } }}</li>
 </ul>
 ```
 


### PR DESCRIPTION
When using the pipe this `{{'things' | translate:"{ count: 2 }"}}` fails, because the translateParams-object is forwarded as a string.