### PR TITLE
Fix error when using a formatter and no customFormatters were passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can override the values used when configuring MessageFormat by providing a c
 ```ts
 {
   biDiSupport: false,
-  formatters: undefined,
+  formatters: {},
   strictNumberSign: false
 }
 ```

--- a/src/lib/message-format-config.ts
+++ b/src/lib/message-format-config.ts
@@ -15,6 +15,6 @@ export interface MessageFormatConfig {
 
 export const defaultConfig: MessageFormatConfig = {
   biDiSupport: false,
-  formatters: undefined,
+  formatters: {},
   strictNumberSign: false,
 };

--- a/src/lib/translate-message-format-compiler.spec.ts
+++ b/src/lib/translate-message-format-compiler.spec.ts
@@ -101,10 +101,13 @@ describe("TranslateMessageFormatCompiler", () => {
 
   describe("compile", () => {
     let icuString: string;
+    let numberIcuString: string;
 
     beforeEach(() => {
       icuString =
         "{count, plural, =0{No} one{A} other{Several}} {count, plural, one{word} other{words}}";
+
+      numberIcuString = "Pi is approximately {pi, number, integer}";
     });
 
     beforeEach(() => {
@@ -119,6 +122,11 @@ describe("TranslateMessageFormatCompiler", () => {
     it("should return the compilation function for composed locales", () => {
       const result = compiler.compile(icuString, "en-GB");
       expect(result({ count: 1 })).toBe("A word");
+    });
+
+    it("should use the number formatter correctly", () => {
+      const result = compiler.compile(numberIcuString, "en");
+      expect(result({ pi: Math.PI })).toBe("Pi is approximately 3");
     });
   });
 


### PR DESCRIPTION
There's an error when the user use a formatter (like number), after no customFormatters were passed to messageformat

The error : 
`TypeError: can't access property "number", this.options.customFormatters is undefined in https://example.com/vendor.js (line XXX)`

This PR fix the issue (see test)

I wonder if it should be fixed in messageformat's repo too