### PR TITLE
Fix performance issue with large translation files

### DIFF
--- a/src/lib/translate-message-format-compiler.ts
+++ b/src/lib/translate-message-format-compiler.ts
@@ -52,11 +52,12 @@ export class TranslateMessageFormatCompiler extends TranslateCompiler {
     }
 
     return Object.keys(translations).reduce<{ [key: string]: any }>(
-      (acc, key) => {
-        const value = translations[key];
-        return { ...acc, [key]: this.compileTranslations(value, lang) };
-      },
-      {}
+        (acc, key) => {
+          const value = translations[key];
+          acc[key] = this.compileTranslations(value, lang);
+          return acc;
+        },
+        {}
     );
   }
 


### PR DESCRIPTION
Fixes extremely slow performance when compiling large translation files.

The fix was originally proposed in https://github.com/lephyrus/ngx-translate-messageformat-compiler/issues/110 by @g1tc4t