### PR TITLE
Fix performance for compiler for very large files 

### DIFF
--- a/src/lib/translate-message-format-compiler.ts
+++ b/src/lib/translate-message-format-compiler.ts
@@ -54,7 +54,8 @@ export class TranslateMessageFormatCompiler extends TranslateCompiler {
     return Object.keys(translations).reduce<{ [key: string]: any }>(
       (acc, key) => {
         const value = translations[key];
-        return { ...acc, [key]: this.compileTranslations(value, lang) };
+        acc[key] = this.compileTranslations(value, lang);
+        return acc;
       },
       {}
     );


### PR DESCRIPTION
There was an existing [PR](https://github.com/lephyrus/ngx-translate-messageformat-compiler/pull/111) to improve performance but there was a build failure due to formatting and there was no update after. Since we are also running into this issue, I wanted to put up the fix for it. If this is against etiquette my apologies in advance! 

This is based on the same fix proposed in issue #110.