### PR TITLE
Allow fallback to default syntax with `fallbackPrefix` on individual messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.0.0] - 2024-02-09
+### Added
+- **Breaking Change** Catch and log errors during message compilation and
+  interpolation by default (#47, #97, #102): provide `throwOnError: true` to
+  restore the previous behaviour
+- Allow for transitional period by assuming that messages that start with the
+  provided `fallbackPrefix` use ngx-translate default syntax (#30)
+
 ## [6.5.1] - 2024-01-04
 ### Fixed
 - Avoid unnecessarily slow processing of (lots of) translations in

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ You can override the values used when configuring MessageFormat by providing a c
   formatters: {},
   strictNumberSign: false,
   currency: "USD",
-  strictPluralKeys: true
-  throwOnError: false
+  strictPluralKeys: true,
+  throwOnError: false,
+  fallbackPrefix: undefined
 }
 ```
 
@@ -101,6 +102,30 @@ Here's two important differences to _ngx-translate_'s default syntax when using 
 
 - You lose the ability to access object properties in your placeholders: `'Hello {name.first} {name.last}'` won't work.
 - Simple placeholders are enclosed in single curly braces instead of double curly braces: `Hello {name}`
+
+### Transitioning from _ngx-translate_ default syntax to _MessageFormat_ syntax
+
+If you have to transition on a message-by-message basis, you can do so by configuring a prefix that, if found on the message, will cause falling back to _ngx-translate_'s default message interpolation.
+
+```ts
+import { MESSAGE_FORMAT_CONFIG } from 'ngx-translate-messageformat-compiler';
+
+@NgModule({
+  // ...
+  providers: [{
+    provide: MESSAGE_FORMAT_CONFIG,
+    useValue: {
+      fallbackPrefix: 'your_choice::'
+    }
+  }]
+```
+
+``` json
+{
+  "uses-messageformat-syntax": "{ COUNT, plural, =0 {There are no results.} one {There is one result.} other {There are # results.}",
+  "uses-default-syntax": "'your_choice::Hello {{name}}."
+}
+```
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Here's two important differences to _ngx-translate_'s default syntax when using 
 
 ### Transitioning from _ngx-translate_ default syntax to _MessageFormat_ syntax
 
-If you have to transition on a message-by-message basis, you can do so by configuring a prefix that, if found on the message, will cause falling back to _ngx-translate_'s default message interpolation.
+If you have to transition on a message-by-message basis, you can do so by configuring a prefix that, if found on the message, will cause the compiler to "ignore" the message. This has the effect of falling back on _ngx-translate_'s default message interpolation.
 
 ```ts
 import { MESSAGE_FORMAT_CONFIG } from 'ngx-translate-messageformat-compiler';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-translate-messageformat-compiler",
-  "version": "6.5.1",
+  "version": "7.0.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build",

--- a/src/lib/message-format-config.ts
+++ b/src/lib/message-format-config.ts
@@ -14,6 +14,7 @@ export interface MessageFormatConfig {
   currency?: string;
   strictPluralKeys?: boolean;
   throwOnError?: boolean;
+  fallbackPrefix?: string;
 }
 
 export const defaultConfig: MessageFormatConfig = {
@@ -23,4 +24,5 @@ export const defaultConfig: MessageFormatConfig = {
   currency: "USD",
   strictPluralKeys: true,
   throwOnError: false,
+  fallbackPrefix: undefined,
 };

--- a/src/lib/translate-message-format-compiler.spec.ts
+++ b/src/lib/translate-message-format-compiler.spec.ts
@@ -140,7 +140,9 @@ describe("TranslateMessageFormatCompiler", () => {
       expect(compiler.compile(null as any, "en")({ sweet: "cookie" })).toBe(
         "null"
       );
-      expect(compiler.compile(legalMsg, "en")(null)).toBe("gimme {sweet}");
+      expect(compiler.compile(legalMsg, "en")(null as any)).toBe(
+        "gimme {sweet}"
+      );
 
       compiler = new TranslateMessageFormatCompiler({ throwOnError: true });
 
@@ -150,8 +152,21 @@ describe("TranslateMessageFormatCompiler", () => {
       expect(() => compiler.compile(null as any, "en")).toThrowError(
         /Cannot convert undefined or null/
       );
-      expect(() => compiler.compile(legalMsg, "en")(null)).toThrowError(
+      expect(() => compiler.compile(legalMsg, "en")(null as any)).toThrowError(
         /Cannot read properties of null/
+      );
+    });
+
+    it("should respect passed-in fallbackPrefix value", () => {
+      compiler = new TranslateMessageFormatCompiler({
+        fallbackPrefix: "fallback:",
+      });
+
+      const message = "{{greeting}}";
+
+      expect(compiler.compile(message, "en")({ greeting: "hi" })).toBe("{hi}");
+      expect(compiler.compile<string>("fallback:" + message, "en")).toBe(
+        "{{greeting}}"
       );
     });
   });


### PR DESCRIPTION
... and bypass compiler if a message has that prefix.

Closes #30.